### PR TITLE
Update Last Man Standing plugin to version 1.1

### DIFF
--- a/plugins/lms-start-notifier
+++ b/plugins/lms-start-notifier
@@ -1,2 +1,2 @@
 repository=https://github.com/pwatts6060/lms-start-notifier.git
-commit=8703fb45412c68b137719184bd5222a77b56ef91
+commit=92cb1b8c94d4ba4073a29bda3338e5c266f8ada7


### PR DESCRIPTION
Add feature to always show hint arrows pointing to the safe zone, even when you're too far away for the client to render the hint. (Done by changing the hint to a closer point in the same direction). Add toggle for the game start notification.